### PR TITLE
Add Ubuntu font to the preferred font list.

### DIFF
--- a/js/conf.example.js
+++ b/js/conf.example.js
@@ -8,7 +8,7 @@
         },
         jenky: {
             updateInterval: 10 * seconds,
-            font: 'freight-sans-pro, Helvetica, Segoe UI, sans-serif',
+            font: 'freight-sans-pro, Ubuntu, Helvetica, Segoe UI, sans-serif',
             typekitKitId: null
         }
     };


### PR DESCRIPTION
It's closer to freight sans pro than the default browser sans-serif font.
