### PR TITLE
When a new project has been created but not yet run, the template throws a TypeError

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         </script>
 
         <script type="text/template" id="job-template">
-            <% if (lastBuild.building) { %>
+            <% if (!_.isNull(lastBuild) && lastBuild.building) { %>
                 <h2 class="<%= previousColor %>"><%= displayName %></h2>
                 <h2 class="progress <%= color %>"><%= displayName %></h2>
             <% } else { %>


### PR DESCRIPTION
Jenkins 1.500 returns this json for a new, un-run project: `... "lastBuild":null`. When the job-template is rendered for that project, I've added a null check before looking for the building param, avoiding the TypeError. It results in the project showing up as grey in the radiator, and all of the rest of the jobs rendering as normal.
